### PR TITLE
Fixes

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -851,13 +851,11 @@ Apify.main(async () => {
                             const interval = setInterval(extracted, 10000);
 
                             try {
-                                for (const { zpid, plid, lotId, detailUrl } of results) {
+                                for (const { zpid, detailUrl } of results) {
                                     await dump(zpid, results);
 
-                                    const zpidValue = zpid || lotId || plid;
-
-                                    if (zpidValue && detailUrl) {
-                                        await processZpid(zpidValue, detailUrl);
+                                    if (zpid) {
+                                        await processZpid(zpid, detailUrl);
 
                                         if (isOverItems()) {
                                             break; // optimize runtime

--- a/src/main.js
+++ b/src/main.js
@@ -140,7 +140,7 @@ Apify.main(async () => {
 
     const zpids = new Set(await Apify.getValue('STATE'));
 
-    Apify.events.on('persistState', async () => {
+    Apify.events.on('migrating', async () => {
         await Apify.setValue('STATE', [...zpids.values()]);
     });
 


### PR DESCRIPTION
Fixes apify-projects/delivery-issue-tracker/issues/355

- handles captcha causing extraction exit before map splitting (retries request if 0 results have been found)
- splits the map for listings under 500 limit (many results are missed without the splitting, e.g. only 100 results out of 150 are scraped without map splitting)
- ignore `input.type` if `input.startUrls` is set (if they're conflicting, actor keeps scraping without saving any results)